### PR TITLE
Improve Write List

### DIFF
--- a/.changeset/improve-write-list.md
+++ b/.changeset/improve-write-list.md
@@ -1,0 +1,5 @@
+---
+"@izumisy/mcp-universal-db-client": patch
+---
+
+Improved the read-only query validation by adding more sql write operations to the WRITE_OPERATIONS set

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -28,7 +28,7 @@ const WRITE_OPERATIONS = new Set([
   "exec",
   "execute",
   "start",
-  "begin"
+  "begin",
 ]);
 
 /**

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -16,6 +16,19 @@ const WRITE_OPERATIONS = new Set([
   "truncate",
   "merge",
   "rename",
+  "set",
+  "grant",
+  "revoke",
+  "begin",
+  "commit",
+  "rollback",
+  "lock",
+  "unlock",
+  "copy",
+  "exec",
+  "execute",
+  "start",
+  "begin"
 ]);
 
 /**


### PR DESCRIPTION
Added more Dangerous Write Commands to the Write list.
Further keep in mind that SELECT INTO OUTFILE and SELECT INTO DUMPFILE allows writing files, which contradicts the read-only restriction. 
Further, LOAD_FILE is often overlooked and might allow to read arbitrary files if the SQL Server is poorly configured.
